### PR TITLE
Support android usb by usb_serial.

### DIFF
--- a/lib/src/modbus_client_serial.dart
+++ b/lib/src/modbus_client_serial.dart
@@ -1,12 +1,14 @@
 library modbus_client_serial_impl;
 
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:libserialport/libserialport.dart';
 import 'package:synchronized/synchronized.dart';
 import 'package:modbus_client/modbus_client.dart';
 import 'package:modbus_client_serial/modbus_client_serial.dart';
+import 'package:usb_serial/usb_serial.dart';
 
 part 'modbus_client_serial_rtu.dart';
 part 'modbus_client_serial_ascii.dart';
@@ -21,7 +23,9 @@ abstract class ModbusClientSerial extends ModbusClient {
   final SerialFlowControl flowControl;
 
   SerialPort? _serialPort;
+  UsbPort? _androidUsbPort;
   SerialPortConfig? _serialConfig;
+
   final Lock _lock = Lock();
 
   ModbusClientSerial(
@@ -42,7 +46,7 @@ abstract class ModbusClientSerial extends ModbusClient {
   Uint8List _getTxTelegram(ModbusRequest request, int unitId);
 
   /// Read response from device.
-  ModbusResponseCode _readResponseHeader(
+  Future<ModbusResponseCode> _readResponseHeader(
       _ModbusSerialResponse response, int timeoutMillis);
 
   /// Reads the full pdu response from device.
@@ -53,16 +57,27 @@ abstract class ModbusClientSerial extends ModbusClient {
 
   /// Returns true if connection is established
   @override
-  bool get isConnected => _serialPort != null;
+  bool get isConnected {
+    if (Platform.isAndroid) {
+      return _androidUsbPort == null;
+    } else {
+      return _serialPort != null;
+    }
+  }
 
   /// Close the connection
   @override
   Future<void> disconnect() async {
     ModbusAppLogger.fine("Closing serial port $portName...");
-    if (_serialPort != null) {
-      _serialPort!.close();
-      _serialPort!.dispose();
-      _serialPort = null;
+    if (Platform.isAndroid) {
+      _androidUsbPort?.close();
+      _androidUsbPort = null;
+    } else {
+      if (_serialPort != null) {
+        _serialPort!.close();
+        _serialPort!.dispose();
+        _serialPort = null;
+      }
     }
     if (_serialConfig != null) {
       //_serialConfig!.dispose(); Config already disposed!
@@ -99,12 +114,22 @@ abstract class ModbusClientSerial extends ModbusClient {
       var unitId = getUnitId(request);
       try {
         // Flush both tx & rx buffers (discard old pending requests & responses)
-        _serialPort!.flush();
+        if (!Platform.isAndroid) {
+          _serialPort!.flush();
+        }
 
         // Sent the serial telegram
         var reqTxData = _getTxTelegram(request, unitId);
-        int txDataCount =
-            _serialPort!.write(reqTxData, timeout: resTimeoutMillis);
+        int txDataCount;
+        if (Platform.isAndroid) {
+          await _androidUsbPort!
+              .write(reqTxData)
+              .timeout(Duration(milliseconds: resTimeoutMillis));
+          txDataCount = reqTxData.length;
+        } else {
+          txDataCount =
+              _serialPort!.write(reqTxData, timeout: resTimeoutMillis);
+        }
         if (txDataCount < reqTxData.length) {
           request.setResponseCode(ModbusResponseCode.requestTimeout);
           return request.responseCode;
@@ -124,7 +149,7 @@ abstract class ModbusClientSerial extends ModbusClient {
           checksumByteCount: checksumByteCount);
       int remainingMillis = resTimeoutMillis - reqStopwatch.elapsedMilliseconds;
       var responseCode = remainingMillis > 0
-          ? _readResponseHeader(response, remainingMillis)
+          ? await _readResponseHeader(response, remainingMillis)
           : ModbusResponseCode.requestTimeout;
       if (responseCode != ModbusResponseCode.requestSucceed) {
         request.setResponseCode(responseCode);
@@ -162,22 +187,70 @@ abstract class ModbusClientSerial extends ModbusClient {
 
     ModbusAppLogger.fine("Opening serial port $portName...");
     // New connection
-    _serialPort = SerialPort(portName);
-    if (!_serialPort!.openReadWrite()) {
-      _serialPort!.dispose();
-      return false;
+    if (Platform.isAndroid) {
+      final androidUsbDevice = (await UsbSerial.listDevices())
+          .firstWhere((d) => d.deviceName == portName);
+      _androidUsbPort = await androidUsbDevice.create();
+      if (_androidUsbPort == null) {
+        return false;
+      }
+      var opened = await _androidUsbPort!.open();
+      if (!opened) {
+        _androidUsbPort!.close();
+        return false;
+      }
+
+      _serialConfig = SerialPortConfig()
+        ..baudRate = baudRate.intValue
+        ..bits = dataBits.intValue
+        ..stopBits = stopBits.intValue
+        ..parity = parity.intValue
+        ..setFlowControl(flowControl.intValue);
+
+      int flow;
+      switch (flowControl.intValue) {
+        case 0:
+          flow = 0;
+          break;
+        case 2:
+          flow = 1;
+          break;
+        case 3:
+          flow = 2;
+          break;
+        case 1:
+          flow = 3;
+          break;
+        default:
+          flow = 0;
+          break;
+      }
+      _androidUsbPort!.setFlowControl(flow);
+      _androidUsbPort!.setPortParameters(
+        baudRate.intValue,
+        dataBits.intValue,
+        stopBits.intValue,
+        parity.intValue,
+      );
+      return true;
+    } else {
+      _serialPort = SerialPort(portName);
+      if (!_serialPort!.openReadWrite()) {
+        _serialPort!.dispose();
+        return false;
+      }
+
+      // Update the config for your setup
+      _serialConfig = SerialPortConfig()
+        ..baudRate = baudRate.intValue
+        ..bits = dataBits.intValue
+        ..stopBits = stopBits.intValue
+        ..parity = parity.intValue
+        ..setFlowControl(flowControl.intValue);
+      _serialPort!.config = _serialConfig!;
+
+      return true;
     }
-
-    // Update the config for your setup
-    _serialConfig = SerialPortConfig()
-      ..baudRate = baudRate.intValue
-      ..bits = dataBits.intValue
-      ..stopBits = stopBits.intValue
-      ..parity = parity.intValue
-      ..setFlowControl(flowControl.intValue);
-    _serialPort!.config = _serialConfig!;
-
-    return true;
   }
 }
 

--- a/lib/src/modbus_client_serial_ascii.dart
+++ b/lib/src/modbus_client_serial_ascii.dart
@@ -30,13 +30,36 @@ class ModbusClientSerialAscii extends ModbusClientSerial {
 
   /// Read response from device.
   @override
-  ModbusResponseCode _readResponseHeader(
-      _ModbusSerialResponse response, int timeoutMillis) {
+  Future<ModbusResponseCode> _readResponseHeader(
+      _ModbusSerialResponse response, int timeoutMillis) async {
     try {
       // Read header data
       var byteCount = 3 * 2 + 1;
-      var rxData = _serialPort!.read(byteCount, timeout: timeoutMillis);
+      Uint8List rxData;
+      if (Platform.isAndroid) {
+        List<int> inData = [];
+        final completer = Completer<Uint8List>();
+        final timeout = Duration(milliseconds: timeoutMillis);
 
+        StreamSubscription<List<int>> subscription;
+        subscription = _androidUsbPort!.inputStream!.listen((data) {
+          inData.addAll(data);
+          if (inData.length >= byteCount) {
+            completer.complete(Uint8List.fromList(inData));
+          }
+        }, onError: (error) {
+          completer.completeError(error);
+        }, cancelOnError: true);
+        rxData = await completer.future.timeout(timeout, onTimeout: () {
+          subscription.cancel();
+          throw TimeoutException('Read operation timed out');
+        });
+        try {
+          subscription.cancel();
+        } catch (_) {}
+      } else {
+        rxData = _serialPort!.read(byteCount, timeout: timeoutMillis);
+      }
       // Received requested data?
       if (rxData.length < byteCount) {
         return ModbusResponseCode.requestTimeout;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   logging: ^1.2.0
   libserialport: ^0.3.0+1
+  usb_serial: ^0.5.2
   synchronized: ^3.1.0
   modbus_client: ^1.3.1
 


### PR DESCRIPTION
In my testing, even after pre-processing the permissions and successfully establishing serial port communication through the Android API, `libserialport` still returns 'Permission denied errno = 13'. Therefore, I've used the Usb_serial plugin to handle all read/write operations on Android separately.

The testing was conducted on an Android 11 phone. I don't have an embedded devices at the moment, so testing on those has not been done. 

Please feel free to provide feedback if find any errors.