### PR TITLE
Synchronize the `flushOnRequest` parameter from `modbus_client`.

### DIFF
--- a/lib/src/modbus_client_serial_ascii.dart
+++ b/lib/src/modbus_client_serial_ascii.dart
@@ -12,7 +12,8 @@ class ModbusClientSerialAscii extends ModbusClientSerialAsciiBase {
       SerialStopBits stopBits = SerialStopBits.one,
       SerialParity parity = SerialParity.none,
       SerialFlowControl flowControl = SerialFlowControl.rtsCts,
-      super.responseTimeout = const Duration(seconds: 3)})
+      super.responseTimeout = const Duration(seconds: 3),
+      super.flushOnRequest = true})
       : super(
             serialPort: LibSerialPort(
                 portName, baudRate, dataBits, stopBits, parity, flowControl));

--- a/lib/src/modbus_client_serial_rtu.dart
+++ b/lib/src/modbus_client_serial_rtu.dart
@@ -12,7 +12,8 @@ class ModbusClientSerialRtu extends ModbusClientSerialRtuBase {
       SerialStopBits stopBits = SerialStopBits.one,
       SerialParity parity = SerialParity.none,
       SerialFlowControl flowControl = SerialFlowControl.rtsCts,
-      super.responseTimeout = const Duration(seconds: 3)})
+      super.responseTimeout = const Duration(seconds: 3),
+      super.flushOnRequest = true})
       : super(
             serialPort: LibSerialPort(
                 portName, baudRate, dataBits, stopBits, parity, flowControl));


### PR DESCRIPTION
Synchronized modifications related to [modbus_client issue #11](https://github.com/cabbi/modbus_client/issues/11#issue-2965493609).